### PR TITLE
add a 'validate_clocksource' function to the bash bench-base library

### DIFF
--- a/bash/library/bench-base
+++ b/bash/library/bench-base
@@ -89,3 +89,27 @@ function validate_sw_prereqs() {
         exit 1
     fi
 }
+
+function validate_clocksource() {
+    local clocksource clocksource_dir available_clocksources
+
+    clocksource_dir="/sys/devices/system/clocksource/clocksource0"
+
+    if pushd ${clocksource_dir} > /dev/null; then
+        clocksource=$(cat current_clocksource)
+        available_clocksources=$(cat available_clocksource)
+
+        popd > /dev/null
+
+        if [ "${clocksource}" != "tsc" ]; then
+            echo "ERROR: Clocksource is not TSC.  Current clocksource is ${clocksource}.  Available clocksources are: ${available_clocksources}"
+            exit 2
+        else
+            echo "Verified clocksource is TSC"
+            return 0
+        fi
+    else
+        echo "ERROR: Could not pushd to ${clocksource_dir}"
+        exit 1
+    fi
+}


### PR DESCRIPTION
- The 'validate_clocksource' function checks that the clocksource is
  set to TSC and exits with an error if that is either not true or
  cannot be validated.  This will be useful in certain workloads
  (ie. latency sensitive workloads like cyclictest, oslat, etc.) that
  require TSC level performance for timer interrupts.