### PR TITLE
fixing dpdk-devbind invocation

### DIFF
--- a/bash/library/bench-base
+++ b/bash/library/bench-base
@@ -41,7 +41,7 @@ function dump_runtime() {
     cat /proc/meminfo
     echo
     echo DPDK devices:
-    dpdk-devbind -s
+    dpdk-devbind.py -s
     echo
     echo netdevs:
     ls -l /sys/class/net


### PR DESCRIPTION
The full name dpdk-devbind.py needs to be used, or you will get this error:

iterations/iteration-1/sample-2/server/1/trafficgen-server-start-stderrout.txt:/opt/toolbox/bash/library/bench-base: line 44: dpdk-devbind: command not found

This has to be done in two more repositories (bench-hwlatdetect & tracer-base).  Not sure how to do this all at once so one at a time.  2:00 EST discussion ?