### PR TITLE
shallow copy new sample into stored, avoids false equality

### DIFF
--- a/python/toolbox/metrics.py
+++ b/python/toolbox/metrics.py
@@ -117,7 +117,7 @@ def log_sample(this_file_id: str, desc: object, names: object, sample: object):
         # Check for and open this file now.
         if file_id not in metric_data_fh:
             metric_data_fh[file_id] = lzma.open(metric_data_file, "wt")
-        stored_sample[idx] = sample
+        stored_sample[idx] = sample.copy()
 
 def finish_samples():
     global file_id, stored_sample, interval, metric_idx, metric_types


### PR DESCRIPTION
Using shallow copy updates the stored_sample so that the rest of the logic works as intended. I am not sure why this is only now an issue. 