### PR TITLE
Re-design all-in-one json schema & enable multiple values

### DIFF
--- a/JSON/oslat-all-in-one.json.example
+++ b/JSON/oslat-all-in-one.json.example
@@ -26,15 +26,19 @@
     "tags": {
         "run": "single-jsonTAGS"
     },
-    "endpoint": {
-        "k8s": "",
-        "COMMON_ENDPOINT_ARGS": "",
-        "COMMON_K8S_ENDPOINT_ARGS": "",
-        "client": "1-2",
-        "server": "1",
-        "cpu-partitioning": "default:1",
-        "securityContext": "client-1:SCRIPT_DIR/k8s-endpoint/securityContext-oslat.json",
-        "securityContext": "client-2:SCRIPT_DIR/k8s-endpoint/securityContext-oslat.json"
-    },
+    "endpoint": [
+        {
+            "type": "k8s",
+            "COMMON_ENDPOINT_ARGS": "",
+            "COMMON_K8S_ENDPOINT_ARGS": "",
+            "client": "1-2",
+            "server": "1",
+            "cpu-partitioning": [ "default:1" ],
+            "securityContext": [
+                "client-1:SCRIPT_DIR/k8s-endpoint/securityContext-oslat.json",
+                "client-2:SCRIPT_DIR/k8s-endpoint/securityContext-oslat.json"
+            ]
+        }
+    ],
     "passthru-args": ""
 }

--- a/JSON/schema.json
+++ b/JSON/schema.json
@@ -14,10 +14,16 @@
             }
         },
         "tags": {
-            "type": "object"
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "endpoint": {
-            "type": "object"
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/endpoint_args"
+            }
         },
         "tool-params": {
             "type": "array"
@@ -32,5 +38,29 @@
     "additionalProperties": false,
     "required": [
         "mv-params"
-    ]
+    ],
+    "definitions": {
+        "endpoint_args": {
+            "type": "object",
+            "patternProperties": {
+                "^.+$": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "minItems": 1,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minLength": 1
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 0
+                        }
+                    ]
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Allow multi-value for single-key in json streams. Users may define string or list (array) to config sections that are transformed to streams (endpoint or tags).