### PR TITLE
Add unit tests

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -7,6 +7,7 @@ on:
     - LICENSE
     - '**.md'
     - .github/workflows/faux-crucible-ci.yaml
+    - .github/workflows/faux-unittest.yaml
     - 'docs/**'
   workflow_dispatch:
 

--- a/.github/workflows/faux-crucible-ci.yaml
+++ b/.github/workflows/faux-crucible-ci.yaml
@@ -7,6 +7,7 @@ on:
     - LICENSE
     - '**.md'
     - .github/workflows/faux-crucible-ci.yaml
+    - .github/workflows/faux-unittest.yaml
     - 'docs/**'
 
 jobs:

--- a/.github/workflows/faux-unittest.yaml
+++ b/.github/workflows/faux-unittest.yaml
@@ -1,0 +1,18 @@
+name: faux-unittest
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - LICENSE
+      - '**.md'
+      - .github/workflows/faux-unittest.yaml
+      - .github/workflows/faux-crucible-ci.yaml
+      - 'docs/**'
+
+jobs:
+  unittest-complete:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Confirm Success
+      run: echo "faux-unittest-complete"

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -1,0 +1,36 @@
+name: unittest
+
+on:
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  get-json-config:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          cd bin
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install pytest pytest-html jsonschema
+
+      - name: Run unit tests
+        run: |
+          cd bin
+          source .venv/bin/activate
+          # TODO: rename files with dash that are used as modules e.g. get-json-config.py
+          # Workaround is to create a symlink to the file or use __import__("foo-bar")
+          pytest -v --html=report.html --self-contained-html getjsonconfig.py tests/*.py
+
+      - name: Upload html report
+        uses: actions/upload-artifact@v2
+        with:
+          name: report
+          path: bin/report.html
+

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -3,8 +3,18 @@ name: unittest
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - LICENSE
+      - '**.md'
+      - .github/workflows/faux-unittest.yaml
+      - .github/workflows/faux-crucible-ci.yaml
+      - 'docs/**'
 
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}/unittest
+  cancel-in-progress: true
 
 jobs:
   get-json-config:
@@ -34,3 +44,10 @@ jobs:
           name: report
           path: bin/report.html
 
+  unittest-complete:
+    runs-on: ubuntu-latest
+    needs:
+    - get-json-config
+    steps:
+    - name: Confirm Success
+      run: echo "unittest-complete"

--- a/bin/getjsonconfig.py
+++ b/bin/getjsonconfig.py
@@ -1,0 +1,1 @@
+get-json-config.py

--- a/bin/tests/JSON/input-oslat-k8s.json
+++ b/bin/tests/JSON/input-oslat-k8s.json
@@ -1,0 +1,48 @@
+{
+    "mv-params": {
+        "global-options": [
+            {
+                "name": "common-params",
+                "params": [
+                    { "arg": "duration", "vals": [ "10" ], "role": "client" },
+                    { "arg": "rtprio", "vals": [ "1" ], "role": "client" }
+                ]
+            }
+        ],
+        "sets": [
+            {
+                "include": "common-params"
+            }
+        ]
+    },
+    "tool-params": [
+        {
+            "tool": "sysstat",
+            "params": [
+                { "arg": "subtools", "val": "mpstat", "enabled": "yes" }
+            ]
+        },
+        {
+            "tool": "procstat"
+        }
+    ],
+    "tags": {
+        "run": "single-json-all-in-one",
+        "userenv": "alma8"
+    },
+    "endpoint": [
+        {
+            "": "k8s",
+            "controller-ip": "CONTROLLER_IP",
+            "host": "CI_ENDPOINT_HOST",
+            "user": "CI_ENDPOINT_USER",
+            "unique-project": "1",
+            "kubeconfig": "0",
+            "client": "1",
+            "server": "1",
+            "cpu-partitioning": [ "default:1" ],
+            "securityContext": "client-1:SCRIPT_DIR/k8s-endpoint/securityContext-oslat.json"
+        }
+    ],
+    "passthru-args": " --num-samples 1 --test-order s"
+}

--- a/bin/tests/JSON/output-oslat-k8s-endpoints.stream
+++ b/bin/tests/JSON/output-oslat-k8s-endpoints.stream
@@ -1,0 +1,1 @@
+k8s,controller-ip:CONTROLLER_IP,host:CI_ENDPOINT_HOST,user:CI_ENDPOINT_USER,unique-project:1,kubeconfig:0,client:1,server:1,cpu-partitioning:default:1,securityContext:client-1:SCRIPT_DIR/k8s-endpoint/securityContext-oslat.json

--- a/bin/tests/JSON/output-oslat-passthru-args.stream
+++ b/bin/tests/JSON/output-oslat-passthru-args.stream
@@ -1,0 +1,1 @@
+" --num-samples 1 --test-order s"

--- a/bin/tests/JSON/output-oslat-tags.stream
+++ b/bin/tests/JSON/output-oslat-tags.stream
@@ -1,0 +1,1 @@
+run:single-json-all-in-one,userenv:alma8

--- a/bin/tests/JSON/output-oslat-tool-params.json
+++ b/bin/tests/JSON/output-oslat-tool-params.json
@@ -1,0 +1,15 @@
+[
+    {
+        "tool": "sysstat",
+        "params": [
+            {
+                "arg": "subtools",
+                "val": "mpstat",
+                "enabled": "yes"
+            }
+        ]
+    },
+    {
+        "tool": "procstat"
+    }
+]

--- a/bin/tests/README.md
+++ b/bin/tests/README.md
@@ -1,0 +1,13 @@
+# Unit tests
+
+## Running unit tests locally
+From the module's root dir:
+```
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install --upgrade pip
+pip3 install pytest jsonchema
+deactivate
+source .venv/bin/activate
+pytest -v tests/test-*
+```

--- a/bin/tests/test-get-json-config.py
+++ b/bin/tests/test-get-json-config.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+import pytest
+import json
+import getjsonconfig
+import re
+
+class TestGetJsonConfig:
+
+    # helper function to read stream from file
+    def _load_file(self, filename):
+        with open("tests/JSON/" + filename, "r") as file:
+            data = file.read().rstrip("\n")
+        return data
+
+    # fixture to load json object from file
+    @pytest.fixture(scope="function")
+    def load_json_file(self, request):
+        return getjsonconfig.load_json_file("tests/JSON/" + request.param)
+
+    """Test if json_to_stream converts endpoint block to a stream"""
+    @pytest.mark.parametrize("load_json_file",
+                             [ "input-oslat-k8s.json" ], indirect=True)
+    def test_json_to_stream_endpoints(self, load_json_file):
+        endpoints_stream = getjsonconfig.json_to_stream(load_json_file, "endpoint", 0)
+        expected_stream = self._load_file("output-oslat-k8s-endpoints.stream")
+
+        assert endpoints_stream == expected_stream
+
+    """Test if json_to_stream converts tags block to a stream"""
+    @pytest.mark.parametrize("load_json_file",
+                             [ "input-oslat-k8s.json" ], indirect=True)
+    def test_json_to_stream_tags(self, load_json_file):
+        tags_stream = getjsonconfig.json_to_stream(load_json_file, "tags", 0)
+        expected_stream = self._load_file("output-oslat-tags.stream")
+
+        assert tags_stream == expected_stream
+
+    """Test if json_to_stream converts passthru-args block to a stream"""
+    @pytest.mark.parametrize("load_json_file",
+                             [ "input-oslat-k8s.json" ], indirect=True)
+    def test_json_to_stream_passthru(self, load_json_file):
+        passthru_stream = getjsonconfig.dump_json(load_json_file, "passthru-args")
+        expected_stream = self._load_file("output-oslat-passthru-args.stream")
+
+        assert passthru_stream == expected_stream
+
+    """Test if load_json_file returns a dict dump_json returns a str"""
+    @pytest.mark.parametrize("load_json_file",
+                             [ "input-oslat-k8s.json" ], indirect=True)
+    def test_dump_json_mvparams(self, load_json_file):
+        assert type(load_json_file) == dict
+        input_json = getjsonconfig.dump_json(load_json_file, "mv-params")
+        assert type(input_json) == str
+
+    """Test if json_to_stream returns None for invalid index"""
+    @pytest.mark.parametrize("load_json_file",
+                             [ "input-oslat-k8s.json" ], indirect=True)
+    def test_json_to_stream_endpoints_invalid_idx(self, load_json_file, capsys):
+        input_json = getjsonconfig.json_to_stream(load_json_file, "endpoint", 1)
+        out, err = capsys.readouterr()
+        assert 'Invalid index' in out
+        assert input_json is None
+


### PR DESCRIPTION
By adding unit tests we enable gradual changes and enhancements to the tools without breaking the code. This change adds a simple test to the get-json-config utility as part of a bigger change to the all-in-one json implementation.