### PR TITLE
Add schema for all supported endpoints

### DIFF
--- a/JSON/schema-kvm.json
+++ b/JSON/schema-kvm.json
@@ -1,0 +1,89 @@
+{
+    "type": "object",
+    "properties": {
+        "type": {
+            "type": "string",
+            "enum": [ "kvm" ]
+        },
+        "controller-ip": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string"
+        },
+        "user": {
+            "type": "string"
+        },
+        "userenv": {
+            "type": "string"
+        },
+        "unique-project": {
+            "type": "integer"
+        },
+        "client": {
+            "type": "integer"
+        },
+        "server": {
+            "type": "integer"
+        },
+        "config": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "targets": {
+                        "anyOf": [
+                            {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "role": {
+                                            "type": "string",
+                                            "enum": [ "client", "server" ]
+                                        },
+                                        "ids": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                        "role",
+                                        "ids"
+                                    ]
+                                }
+                            },
+                            {
+                                "type": "string",
+                                "enum": [ "all", "default" ]
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "$ref": "#/definitions/settings"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "targets",
+                    "settings"
+                ]
+            }
+        }
+    },
+    "additionalProperties": true,
+    "required": [
+        "type",
+        "controller-ip",
+        "host",
+        "user"
+    ],
+    "definitions": {
+        "settings": {
+            "type": "object",
+            "additionalProperties": true
+        }
+   }
+}

--- a/JSON/schema-osp.json
+++ b/JSON/schema-osp.json
@@ -1,0 +1,89 @@
+{
+    "type": "object",
+    "properties": {
+        "type": {
+            "type": "string",
+            "enum": [ "osp" ]
+        },
+        "controller-ip": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string"
+        },
+        "user": {
+            "type": "string"
+        },
+        "userenv": {
+            "type": "string"
+        },
+        "unique-project": {
+            "type": "integer"
+        },
+        "client": {
+            "type": "integer"
+        },
+        "server": {
+            "type": "integer"
+        },
+        "config": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "targets": {
+                        "anyOf": [
+                            {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "role": {
+                                            "type": "string",
+                                            "enum": [ "client", "server" ]
+                                        },
+                                        "ids": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                        "role",
+                                        "ids"
+                                    ]
+                                }
+                            },
+                            {
+                                "type": "string",
+                                "enum": [ "all", "default" ]
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "$ref": "#/definitions/settings"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "targets",
+                    "settings"
+                ]
+            }
+        }
+    },
+    "additionalProperties": true,
+    "required": [
+        "type",
+        "controller-ip",
+        "host",
+        "user"
+    ],
+    "definitions": {
+        "settings": {
+            "type": "object",
+            "additionalProperties": true
+        }
+   }
+}

--- a/JSON/schema-remotehost.json
+++ b/JSON/schema-remotehost.json
@@ -1,0 +1,89 @@
+{
+    "type": "object",
+    "properties": {
+        "type": {
+            "type": "string",
+            "enum": [ "remotehost" ]
+        },
+        "controller-ip": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string"
+        },
+        "user": {
+            "type": "string"
+        },
+        "userenv": {
+            "type": "string"
+        },
+        "unique-project": {
+            "type": "integer"
+        },
+        "client": {
+            "type": "integer"
+        },
+        "server": {
+            "type": "integer"
+        },
+        "config": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "targets": {
+                        "anyOf": [
+                            {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "role": {
+                                            "type": "string",
+                                            "enum": [ "client", "server" ]
+                                        },
+                                        "ids": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                        "role",
+                                        "ids"
+                                    ]
+                                }
+                            },
+                            {
+                                "type": "string",
+                                "enum": [ "all", "default" ]
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "$ref": "#/definitions/settings"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "targets",
+                    "settings"
+                ]
+            }
+        }
+    },
+    "additionalProperties": true,
+    "required": [
+        "type",
+        "controller-ip",
+        "host",
+        "user"
+    ],
+    "definitions": {
+        "settings": {
+            "type": "object",
+            "additionalProperties": true
+        }
+   }
+}

--- a/bin/get-json-config.py
+++ b/bin/get-json-config.py
@@ -172,10 +172,6 @@ def validate_schema(input_json, schema_file = None):
             schema_json = schema_path + schema_default
         else:
             schema_json = schema_path + schema_file
-            if not os.path.isfile(schema_json) or not os.path.exists(schema_json):
-                # TODO: enforce validation when all schemas are created
-                print("JSON schema not found: %s. Skipping validation." % (schema_json))
-                return True
         schema_obj = load_json_file(schema_json)
         if schema_obj is None:
             return False
@@ -199,10 +195,15 @@ def main():
 
     if args.config == "endpoint" or args.config == "tags":
         if args.config == "endpoint":
-            endp = input_json[args.config][args.index]["type"]
-            if not validate_schema(input_json[args.config][args.index],
-                                    "schema-" + endp + ".json"):
+            try:
+                endp = input_json[args.config][args.index]["type"]
+            except:
+                endp = "null"
                 return 1
+            finally:
+                if not validate_schema(input_json[args.config][args.index],
+                                        "schema-" + endp + ".json"):
+                    return 1
         output = json_to_stream(input_json, args.config, args.index)
     else:
         output = dump_json(input_json, args.config)

--- a/bin/tests/JSON/ci-oslat.k8s.json
+++ b/bin/tests/JSON/ci-oslat.k8s.json
@@ -1,0 +1,67 @@
+{
+    "mv-params": {
+        "global-options": [
+            {
+                "name": "common-params",
+                "params": [
+                    { "arg": "duration", "vals": [ "10" ], "role": "client" },
+                    { "arg": "rtprio", "vals": [ "1" ], "role": "client" }
+                ]
+            }
+        ],
+        "sets": [
+            {
+                "include": "common-params"
+            }
+        ]
+    },
+    "tool-params": [
+        {
+            "tool": "sysstat",
+            "params": [
+                { "arg": "subtools", "val": "mpstat", "enabled": "yes" }
+            ]
+        },
+        {
+            "tool": "procstat"
+        }
+    ],
+    "tags": {
+        "run": "single-json-all-in-one",
+        "userenv": "alma8"
+    },
+    "endpoint": [
+        {
+            "type": "k8s",
+            "controller-ip": "CONTROLLER_IP",
+            "host": "CI_ENDPOINT_HOST",
+            "user": "CI_ENDPOINT_USER",
+            "userenv": "alma8",
+            "unique-project": 1,
+            "kubeconfig": 0,
+            "server": 1,
+            "client": 1,
+            "config": [
+                {
+                    "targets": [
+                        { "role": "client", "ids": "1" }
+                    ],
+                    "settings": {
+                        "securityContext": {
+                            "capabilities": {
+                                "add": [ "SYS_NICE", "IPC_LOCK" ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "targets": "all",
+                    "settings": {
+                        "cpu-partitioning": 1
+                    }
+                }
+            ]
+        }
+    ],
+    "passthru-args": " --num-samples 1 --test-order s"
+}

--- a/bin/tests/JSON/input-oslat-invalid.json
+++ b/bin/tests/JSON/input-oslat-invalid.json
@@ -1,0 +1,39 @@
+{
+    "mv-params": {
+        "global-options": [
+            {
+                "name": "common-params",
+                "params": [
+                    { "arg": "duration", "vals": [ "10" ], "role": "client" },
+                    { "arg": "rtprio", "vals": [ "1" ], "role": "client" }
+                ]
+            }
+        ],
+        "sets": [
+            {
+                "include": "common-params"
+            }
+        ]
+    },
+    "endpoint": [
+        {
+            "type": "invalid",
+            "controller-ip": "CONTROLLER_IP",
+            "host": "CI_ENDPOINT_HOST",
+            "user": "CI_ENDPOINT_USER",
+            "userenv": "alma8",
+            "unique-project": 1,
+            "server": 1,
+            "client": 1,
+            "config": [
+                {
+                    "targets": "all",
+                    "settings": {
+                        "cpu-partitioning": 1
+                    }
+                }
+            ]
+        }
+    ],
+    "passthru-args": " --num-samples 1 --test-order s"
+}

--- a/bin/tests/JSON/input-oslat-k8s-osp.json
+++ b/bin/tests/JSON/input-oslat-k8s-osp.json
@@ -1,0 +1,66 @@
+{
+    "mv-params": {
+        "global-options": [
+            {
+                "name": "common-params",
+                "params": [
+                    { "arg": "duration", "vals": [ "10" ], "role": "client" },
+                    { "arg": "rtprio", "vals": [ "1" ], "role": "client" }
+                ]
+            }
+        ],
+        "sets": [
+            {
+                "include": "common-params"
+            }
+        ]
+    },
+    "endpoint": [
+        {
+            "type": "k8s",
+            "controller-ip": "CONTROLLER_IP",
+            "host": "ENDPOINT_HOST",
+            "user": "ENDPOINT_USER",
+            "userenv": "alma8",
+            "unique-project": 1,
+            "kubeconfig": 0,
+            "server": 1,
+            "client": 1,
+            "config": [
+                {
+                    "targets": [
+                        { "role": "server", "ids": "1" }
+                    ],
+                    "settings": {
+                        "securityContext": {
+                            "privileged": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "osp",
+            "controller-ip": "CONTROLLER_IP",
+            "host": "ENDPOINT_HOST",
+            "user": "ENDPOINT_USER",
+            "userenv": "alma8",
+            "unique-project": 1,
+            "server": 1,
+            "client": 1,
+            "config": [
+                {
+                    "targets": [
+                        { "role": "client", "ids": "1" }
+                    ],
+                    "settings": {
+                        "custom": {
+                            "custom-setting": true
+                        }
+                    }
+                }
+            ]
+        }
+
+    ]
+}

--- a/bin/tests/JSON/input-oslat-kvm.json
+++ b/bin/tests/JSON/input-oslat-kvm.json
@@ -1,0 +1,39 @@
+{
+    "mv-params": {
+        "global-options": [
+            {
+                "name": "common-params",
+                "params": [
+                    { "arg": "duration", "vals": [ "10" ], "role": "client" },
+                    { "arg": "rtprio", "vals": [ "1" ], "role": "client" }
+                ]
+            }
+        ],
+        "sets": [
+            {
+                "include": "common-params"
+            }
+        ]
+    },
+    "endpoint": [
+        {
+            "type": "kvm",
+            "controller-ip": "CONTROLLER_IP",
+            "host": "CI_ENDPOINT_HOST",
+            "user": "CI_ENDPOINT_USER",
+            "userenv": "alma8",
+            "unique-project": 1,
+            "server": 1,
+            "client": 1,
+            "config": [
+                {
+                    "targets": "all",
+                    "settings": {
+                        "cpu-partitioning": 1
+                    }
+                }
+            ]
+        }
+    ],
+    "passthru-args": " --num-samples 1 --test-order s"
+}

--- a/bin/tests/JSON/input-oslat-notype.json
+++ b/bin/tests/JSON/input-oslat-notype.json
@@ -1,0 +1,39 @@
+{
+    "mv-params": {
+        "global-options": [
+            {
+                "name": "common-params",
+                "params": [
+                    { "arg": "duration", "vals": [ "10" ], "role": "client" },
+                    { "arg": "rtprio", "vals": [ "1" ], "role": "client" }
+                ]
+            }
+        ],
+        "sets": [
+            {
+                "include": "common-params"
+            }
+        ]
+    },
+    "endpoint": [
+        {
+            "no-type": "no-type",
+            "controller-ip": "CONTROLLER_IP",
+            "host": "CI_ENDPOINT_HOST",
+            "user": "CI_ENDPOINT_USER",
+            "userenv": "alma8",
+            "unique-project": 1,
+            "server": 1,
+            "client": 1,
+            "config": [
+                {
+                    "targets": "all",
+                    "settings": {
+                        "cpu-partitioning": 1
+                    }
+                }
+            ]
+        }
+    ],
+    "passthru-args": " --num-samples 1 --test-order s"
+}

--- a/bin/tests/JSON/input-oslat-osp.json
+++ b/bin/tests/JSON/input-oslat-osp.json
@@ -1,0 +1,39 @@
+{
+    "mv-params": {
+        "global-options": [
+            {
+                "name": "common-params",
+                "params": [
+                    { "arg": "duration", "vals": [ "10" ], "role": "client" },
+                    { "arg": "rtprio", "vals": [ "1" ], "role": "client" }
+                ]
+            }
+        ],
+        "sets": [
+            {
+                "include": "common-params"
+            }
+        ]
+    },
+    "endpoint": [
+        {
+            "type": "osp",
+            "controller-ip": "CONTROLLER_IP",
+            "host": "CI_ENDPOINT_HOST",
+            "user": "CI_ENDPOINT_USER",
+            "userenv": "alma8",
+            "unique-project": 1,
+            "server": 1,
+            "client": 1,
+            "config": [
+                {
+                    "targets": "all",
+                    "settings": {
+                        "cpu-partitioning": 1
+                    }
+                }
+            ]
+        }
+    ],
+    "passthru-args": " --num-samples 1 --test-order s"
+}

--- a/bin/tests/JSON/input-oslat-remotehost.json
+++ b/bin/tests/JSON/input-oslat-remotehost.json
@@ -1,0 +1,39 @@
+{
+    "mv-params": {
+        "global-options": [
+            {
+                "name": "common-params",
+                "params": [
+                    { "arg": "duration", "vals": [ "10" ], "role": "client" },
+                    { "arg": "rtprio", "vals": [ "1" ], "role": "client" }
+                ]
+            }
+        ],
+        "sets": [
+            {
+                "include": "common-params"
+            }
+        ]
+    },
+    "endpoint": [
+        {
+            "type": "remotehost",
+            "controller-ip": "CONTROLLER_IP",
+            "host": "CI_ENDPOINT_HOST",
+            "user": "CI_ENDPOINT_USER",
+            "userenv": "alma8",
+            "unique-project": 1,
+            "server": 1,
+            "client": 1,
+            "config": [
+                {
+                    "targets": "all",
+                    "settings": {
+                        "cpu-partitioning": 1
+                    }
+                }
+            ]
+        }
+    ],
+    "passthru-args": " --num-samples 1 --test-order s"
+}

--- a/bin/tests/JSON/output-oslat-k8s-osp.stream
+++ b/bin/tests/JSON/output-oslat-k8s-osp.stream
@@ -1,0 +1,1 @@
+osp,controller-ip:CONTROLLER_IP,host:ENDPOINT_HOST,user:ENDPOINT_USER,userenv:alma8,unique-project:1,server:1,client:1

--- a/bin/tests/test-get-json-config.py
+++ b/bin/tests/test-get-json-config.py
@@ -73,10 +73,67 @@ class TestGetJsonConfig:
         validated_json = getjsonconfig.validate_schema(load_json_file)
         assert validated_json is True
 
-    """Test validate_schema using endpoint schema and returns True"""
+    """Test validate_schema using k8s schema and returns True"""
     @pytest.mark.parametrize("load_json_file",
                              [ "input-oslat-k8s.json" ], indirect=True)
-    def test_validate_schema_endpoint(self, load_json_file):
+    def test_validate_schema_endpoint_k8s(self, load_json_file):
         validated_json = getjsonconfig.validate_schema(
-                             load_json_file["endpoint"], "schema-endpoint.json")
+                             load_json_file["endpoint"][0], "schema-k8s.json")
         assert validated_json is True
+
+    """Test validate_schema using osp schema and returns True"""
+    @pytest.mark.parametrize("load_json_file",
+                             [ "input-oslat-osp.json" ], indirect=True)
+    def test_validate_schema_endpoint_osp(self, load_json_file):
+        validated_json = getjsonconfig.validate_schema(
+                             load_json_file["endpoint"][0], "schema-osp.json")
+        assert validated_json is True
+
+    """Test validate_schema using remotehost schema and returns True"""
+    @pytest.mark.parametrize("load_json_file",
+                             [ "input-oslat-remotehost.json" ], indirect=True)
+    def test_validate_schema_endpoint_remotehost(self, load_json_file):
+        validated_json = getjsonconfig.validate_schema(
+                             load_json_file["endpoint"][0], "schema-remotehost.json")
+        assert validated_json is True
+
+    """Test validate_schema using kvm schema and returns True"""
+    @pytest.mark.parametrize("load_json_file",
+                             [ "input-oslat-kvm.json" ], indirect=True)
+    def test_validate_schema_endpoint_kvm(self, load_json_file):
+        validated_json = getjsonconfig.validate_schema(
+                             load_json_file["endpoint"][0], "schema-kvm.json")
+        assert validated_json is True
+
+    """Test validate_schema using invalid schema and returns False"""
+    @pytest.mark.parametrize("load_json_file",
+                             [ "input-oslat-invalid.json" ], indirect=True)
+    def test_validate_schema_endpoint_invalid(self, load_json_file):
+        validated_json = getjsonconfig.validate_schema(
+                             load_json_file["endpoint"][0], "schema-invalid.json")
+        assert validated_json is False
+
+    """Test validate_schema w/ missing endpoint type and returns False"""
+    @pytest.mark.parametrize("load_json_file",
+                             [ "input-oslat-notype.json" ], indirect=True)
+    def test_validate_schema_endpoint_notype(self, load_json_file):
+        validated_json = getjsonconfig.validate_schema(
+                             load_json_file["endpoint"][0], "schema-null.json")
+        assert validated_json is False
+
+    """Test validate_schema using multiple endpoints and returns True"""
+    @pytest.mark.parametrize("load_json_file",
+                             [ "input-oslat-k8s-osp.json" ], indirect=True)
+    def test_validate_schema_endpoint_k8s_osp(self, load_json_file):
+        validated_json_1 = getjsonconfig.validate_schema(
+                             load_json_file["endpoint"][0], "schema-k8s.json")
+        validated_json_2 = getjsonconfig.validate_schema(
+                             load_json_file["endpoint"][1], "schema-osp.json")
+        endpoints_stream = getjsonconfig.json_to_stream(load_json_file, "endpoint", 1)
+        expected_stream = self._load_file("output-oslat-k8s-osp.stream")
+
+        assert validated_json_1 is True
+        assert validated_json_2 is True
+        # endpoint config generates random stream, so we match only general args
+        assert expected_stream in endpoints_stream
+        assert 'custom:client-1:' in endpoints_stream


### PR DESCRIPTION
k8s endpoint json block now is validated with a specific schema. Other endpoints like osp, kvm and remotehost are validated using a placeholder schema with generic strutucture to be polished with more strict rules.

Added tests to confirm schema validation works for all endpoints. CI run file has been created to be used in the crucible-ci tests.