### PR TITLE
feat: add controller image requirements and use release CI workflow

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -31,10 +31,10 @@ jobs:
       - name: Display changes
         run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 
-  call-real-core-crucible-ci:
+  call-real-core-release-crucible-ci:
     needs: changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
-    uses: perftool-incubator/crucible-ci/.github/workflows/core-crucible-ci.yaml@main
+    uses: perftool-incubator/crucible-ci/.github/workflows/core-release-crucible-ci.yaml@main
     with:
       ci_target: "toolbox"
       ci_target_branch: "${{ github.ref }}"
@@ -43,13 +43,13 @@ jobs:
       ci_registry_auth: ${{ secrets.CRUCIBLE_CI_ENGINES_REGISTRY_AUTH }}
       quay_oauth_token: ${{ secrets.CRUCIBLE_QUAYIO_OAUTH_TOKEN }}
 
-  call-faux-core-crucible-ci:
+  call-faux-core-release-crucible-ci:
     needs: changes
     if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
-    uses: perftool-incubator/crucible-ci/.github/workflows/faux-core-crucible-ci.yaml@main
+    uses: perftool-incubator/crucible-ci/.github/workflows/faux-core-release-crucible-ci.yaml@main
 
   crucible-ci-complete:
-    needs: [ call-real-core-crucible-ci, call-faux-core-crucible-ci ]
+    needs: [ call-real-core-release-crucible-ci, call-faux-core-release-crucible-ci ]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/workshop.json
+++ b/workshop.json
@@ -8,6 +8,13 @@
         {
             "name": "default",
             "requirements": []
+        },
+        {
+            "name": "crucible-controller",
+            "requirements": [
+                "distro-perl-tools",
+                "toolbox-python-deps"
+            ]
         }
     ],
     "requirements": [
@@ -24,6 +31,24 @@
                     "JSON",
                     "JSON::XS",
                     "JSON::Validator"
+                ]
+            }
+        },
+        {
+            "name": "distro-perl-tools",
+            "type": "distro",
+            "distro_info": {
+                "packages": [
+                    "perl-App-cpanminus"
+                ]
+            }
+        },
+        {
+            "name": "toolbox-python-deps",
+            "type": "python3",
+            "python3_info": {
+                "packages": [
+                    "jsonschema"
                 ]
             }
         }


### PR DESCRIPTION
## Summary
- Add perl-App-cpanminus and Python jsonschema to `workshop.json` for the controller image build, alongside the existing CPAN module declarations
- Switch `crucible-ci.yaml` from `core-crucible-ci` to `core-release-crucible-ci` so workshop.json changes trigger a controller image rebuild

Part of the effort to decentralize controller image requirements to individual subprojects.

## Test plan
- [ ] CI passes
- [ ] Controller image builds successfully with toolbox deps resolved from this workshop.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)