### PR TITLE
feat: support multi-instance tool metric source prefixing

### DIFF
--- a/perl/toolbox/metrics.pm
+++ b/perl/toolbox/metrics.pm
@@ -159,6 +159,18 @@ sub log_sample {
     my $desc_ref = shift;
     my $names_ref = shift;
     my $sample_ref = shift;
+
+    if (exists $ENV{'RICKSHAW_TOOL_ID'} and defined $ENV{'RICKSHAW_TOOL_ID'}) {
+        my $tool_id = $ENV{'RICKSHAW_TOOL_ID'};
+        my $prefix = $tool_id . "::";
+        if ($file_id !~ /^\Q$prefix\E/) {
+            $file_id = $prefix . $file_id;
+        }
+        if ($$desc_ref{'source'} !~ /^\Q$prefix\E/) {
+            $$desc_ref{'source'} = $prefix . $$desc_ref{'source'};
+        }
+    }
+
     $metric_data_file_prefix = "metric-data-" . $file_id;
     $metric_data_file = $metric_data_file_prefix . ".csv";
     if ($use_xz == 1) {


### PR DESCRIPTION
## Summary
- When `RICKSHAW_TOOL_ID` is set in the environment, `log_sample` prefixes both the file_id and the metric `source` descriptor with the tool ID (e.g., `sysstat-1sec::mpstat`)
- Ensures CDM keeps metrics from different instances of the same tool separated for correct aggregation
- No-op when the env var is not set (backwards compatible with single-instance tools)
- Companion to the rickshaw multi-instance tool support PR which sets `RICKSHAW_TOOL_ID` during post-processing

## Test plan
- [ ] Run with single-instance tools (no `RICKSHAW_TOOL_ID` set) — verify identical behavior
- [ ] Run with `RICKSHAW_TOOL_ID=sysstat-1sec` set — verify metric files and sources are prefixed with `sysstat-1sec::`
- [ ] Verify no double-prefixing when `log_sample` is called multiple times with the same desc hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)