### PR TITLE
feat: add Python library extensions for rickshaw Perl-to-Python port

### DIFF
--- a/python/toolbox/__init__.py
+++ b/python/toolbox/__init__.py
@@ -1,0 +1,2 @@
+# -*- mode: python; indent-tabs-mode: nil; python-indent-level: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python

--- a/python/toolbox/fileio.py
+++ b/python/toolbox/fileio.py
@@ -1,0 +1,29 @@
+import lzma
+import os
+
+
+def open_write_text_file(filename):
+    """Open a file for writing with automatic xz compression.
+
+    If the filename doesn't already end in '.xz', '.xz' is appended.
+    Returns the opened file handle (text mode) and the actual filename used.
+    """
+    if not filename.endswith(".xz"):
+        filename += ".xz"
+    return lzma.open(filename, "wt"), filename
+
+
+def open_read_text_file(filename):
+    """Open a file for reading with transparent xz decompression.
+
+    If filename.xz exists, it is preferred over the uncompressed version.
+    Returns the opened file handle (text mode) and the actual filename used.
+    """
+    xz_filename = filename + ".xz"
+    if os.path.exists(xz_filename):
+        return lzma.open(xz_filename, "rt"), xz_filename
+    if os.path.exists(filename):
+        if filename.endswith(".xz"):
+            return lzma.open(filename, "rt"), filename
+        return open(filename, "r"), filename
+    raise FileNotFoundError(f"Neither {filename} nor {xz_filename} found")

--- a/python/toolbox/json.py
+++ b/python/toolbox/json.py
@@ -4,6 +4,8 @@ import lzma
 from jsonschema import validate
 from jsonschema import exceptions
 
+from toolbox.fileio import open_write_text_file
+
 
 def load_json_file(json_file, uselzma = False):
     """Load JSON file and return a json object/error msg tuple"""
@@ -27,6 +29,30 @@ def load_json_file(json_file, uselzma = False):
     except TypeError as err:
         err_msg = f"JSON object type error: { err }"
     return None, err_msg
+
+
+def save_json_file(filename, data, schema_file=None):
+    """Save a Python object as JSON with automatic xz compression.
+
+    Returns (actual_filename, error_msg). On success error_msg is None.
+    """
+    if schema_file is not None:
+        valid, err = validate_schema(data, schema_file)
+        if not valid:
+            return None, err
+
+    try:
+        json_text = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    except (TypeError, ValueError) as err:
+        return None, f"Could not encode JSON: {err}"
+
+    try:
+        fh, actual_filename = open_write_text_file(filename)
+        fh.write(json_text)
+        fh.close()
+        return actual_filename, None
+    except OSError as err:
+        return None, f"Could not write file {filename}: {err}"
 
 def validate_schema(input_json, schema_file):
     """Validate json with schema file"""

--- a/python/toolbox/logging.py
+++ b/python/toolbox/logging.py
@@ -1,0 +1,37 @@
+# -*- mode: python; indent-tabs-mode: nil; python-indent-level: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python
+
+import logging
+import sys
+
+
+def setup_logging(name, level="normal"):
+    """Configure logging with a standard format.
+
+    Args:
+        name: logger name (typically the script name)
+        level: "normal", "debug", or a Python logging level name
+
+    Returns:
+        configured logger instance
+    """
+    level_map = {
+        "normal": logging.INFO,
+        "debug": logging.DEBUG,
+        "warning": logging.WARNING,
+        "error": logging.ERROR,
+    }
+
+    log_level = level_map.get(level, logging.INFO)
+
+    logger = logging.getLogger(name)
+    logger.setLevel(log_level)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(log_level)
+        formatter = logging.Formatter("%(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    return logger

--- a/python/toolbox/parallel.py
+++ b/python/toolbox/parallel.py
@@ -1,0 +1,46 @@
+# -*- mode: python; indent-tabs-mode: nil; python-indent-level: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python
+
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+def get_max_workers():
+    """Determine the number of workers based on available CPUs.
+
+    Returns half the CPU count, matching the Perl fork-based approach.
+    Minimum of 1 worker.
+    """
+    cpus = os.cpu_count() or 2
+    return max(1, cpus // 2)
+
+
+def run_parallel_jobs(jobs, worker_fn, max_workers=None):
+    """Execute jobs in parallel using a thread pool.
+
+    Replaces the Perl fork-based pattern where child processes are
+    forked up to max_forked_jobs at a time.
+
+    Args:
+        jobs: iterable of job arguments (each passed to worker_fn)
+        worker_fn: callable that processes a single job
+        max_workers: number of parallel workers (default: half CPU count)
+
+    Returns:
+        list of (job, result) tuples in completion order
+    """
+    if max_workers is None:
+        max_workers = get_max_workers()
+
+    results = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_job = {executor.submit(worker_fn, job): job for job in jobs}
+        for future in as_completed(future_to_job):
+            job = future_to_job[future]
+            try:
+                result = future.result()
+                results.append((job, result))
+            except Exception as exc:
+                results.append((job, exc))
+
+    return results

--- a/python/toolbox/roadblock.py
+++ b/python/toolbox/roadblock.py
@@ -70,6 +70,7 @@ def do_roadblock(roadblock_id, label, role="follower", follower_id=None,
         msgs_log_file = os.path.join(msgs_dir, f"{label}.json")
 
     rb = RoadblockEngine(None, None)
+    rb.user_messages = None
     rb.set_uuid(uuid)
     rb.set_role(role)
     rb.set_timeout(timeout)
@@ -77,7 +78,9 @@ def do_roadblock(roadblock_id, label, role="follower", follower_id=None,
     if role == "leader":
         rb.set_leader_id(leader_id)
         if followers_file:
-            rb.set_followers_file(followers_file)
+            with open(followers_file) as f:
+                followers_list = [line.strip() for line in f if line.strip()]
+            rb.set_followers(followers_list)
     else:
         rb.set_follower_id(follower_id)
         rb.set_leader_id(leader_id)

--- a/python/toolbox/roadblock.py
+++ b/python/toolbox/roadblock.py
@@ -1,0 +1,115 @@
+# -*- mode: python; indent-tabs-mode: nil; python-indent-level: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python
+
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROADBLOCK_HOME = os.environ.get("ROADBLOCK_HOME")
+if ROADBLOCK_HOME is not None:
+    sys.path.append(str(Path(ROADBLOCK_HOME)))
+
+try:
+    from roadblock import roadblock as RoadblockEngine
+except ImportError:
+    RoadblockEngine = None
+
+logger = logging.getLogger(__name__)
+
+ROADBLOCK_EXITS = {
+    "success": 0,
+    "input": 2,
+    "timeout": 3,
+    "abort": 4,
+    "abort_waiting": 6,
+}
+
+
+def do_roadblock(roadblock_id, label, role="follower", follower_id=None,
+                 leader_id="controller", timeout=300, redis_server=None,
+                 redis_password=None, messages=None, followers_file=None,
+                 abort=False, connection_watchdog=True, log_level="normal",
+                 msgs_dir=None):
+    """Run a roadblock synchronization point.
+
+    Supports both leader and follower roles. Uses the roadblock module
+    natively rather than shelling out to roadblocker.py.
+
+    Args:
+        roadblock_id: base ID for the roadblock UUID
+        label: name of this roadblock point
+        role: "leader" or "follower"
+        follower_id: ID when running as follower
+        leader_id: ID of the leader (default: "controller")
+        timeout: seconds to wait before timing out
+        redis_server: redis/valkey server address
+        redis_password: redis/valkey password
+        messages: path to a JSON messages file to send
+        followers_file: path to a file listing follower IDs (leader only)
+        abort: whether to send an abort signal
+        connection_watchdog: enable/disable the connection watchdog
+        log_level: roadblock log level
+        msgs_dir: directory for message log output
+
+    Returns:
+        tuple of (return_code, messages_data)
+    """
+    if RoadblockEngine is None:
+        raise RuntimeError(
+            "roadblock module not available. Set ROADBLOCK_HOME to the "
+            "roadblock project directory."
+        )
+
+    uuid = f"{roadblock_id}:{label}"
+    logger.info("Roadblock: role=%s uuid=%s timeout=%d", role, uuid, timeout)
+
+    msgs_log_file = None
+    if msgs_dir:
+        msgs_log_file = os.path.join(msgs_dir, f"{label}.json")
+
+    rb = RoadblockEngine(None, None)
+    rb.set_uuid(uuid)
+    rb.set_role(role)
+    rb.set_timeout(timeout)
+
+    if role == "leader":
+        rb.set_leader_id(leader_id)
+        if followers_file:
+            rb.set_followers_file(followers_file)
+    else:
+        rb.set_follower_id(follower_id)
+        rb.set_leader_id(leader_id)
+
+    if redis_server:
+        rb.set_redis_server(redis_server)
+    if redis_password:
+        rb.set_redis_password(redis_password)
+    if abort:
+        rb.set_abort(True)
+    if msgs_log_file:
+        rb.set_message_log(msgs_log_file)
+    if messages:
+        rb.set_user_messages(messages)
+
+    watchdog = "enabled" if connection_watchdog else "disabled"
+    rb.set_connection_watchdog(watchdog)
+
+    rc = rb.run_it()
+
+    if rc != ROADBLOCK_EXITS["success"]:
+        logger.error("Roadblock '%s' failed with rc=%d", label, rc)
+    else:
+        logger.info("Roadblock '%s' completed successfully", label)
+
+    messages_data = None
+    if msgs_log_file and os.path.exists(msgs_log_file):
+        import json
+        try:
+            with open(msgs_log_file) as f:
+                messages_data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            logger.warning("Could not read roadblock messages from %s", msgs_log_file)
+
+    return rc, messages_data

--- a/python/toolbox/run.py
+++ b/python/toolbox/run.py
@@ -1,0 +1,23 @@
+# -*- mode: python; indent-tabs-mode: nil; python-indent-level: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python
+
+import invoke
+
+
+def run_cmd(cmd, check=False):
+    """Execute a shell command and return (command, output, rc).
+
+    Matches the Perl toolbox::run run_cmd() interface.
+
+    Args:
+        cmd: shell command string
+        check: if True, raise on non-zero exit
+
+    Returns:
+        tuple of (command_str, combined_output, return_code)
+    """
+    result = invoke.run(cmd, hide=True, warn=not check)
+    output = result.stdout
+    if result.stderr:
+        output += result.stderr
+    return cmd, output, result.return_code


### PR DESCRIPTION
## Summary
- Add `fileio.py` with `open_read_text_file()` and `open_write_text_file()` for transparent xz compression/decompression, matching the Perl `toolbox::json` interface
- Add `save_json_file()` to `json.py` as the write counterpart to `load_json_file()`, with automatic xz compression
- Add `logging.py` with `setup_logging()` for standardized logger configuration
- Add `run.py` with `run_cmd()` via `invoke.run()` for shell command execution
- Add `parallel.py` with `run_parallel_jobs()` using `ThreadPoolExecutor` for parallel job execution
- Add `roadblock.py` with native `do_roadblock()` wrapper supporting leader/follower roles
- Fix roadblock API usage: read followers file into list for `set_followers()`, initialize `user_messages` to `None`

These extensions support the rickshaw Perl-to-Python3 port but are generic enough for any subproject.

## Test plan
- [x] All modules tested via rickshaw Python ports (post-process-tools, post-process-bench, gen-docs, rickshaw-run)
- [x] End-to-end validated with `crucible run` using fio and uperf+iperf benchmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)