### PR TITLE
feat: add CDMMetrics class and cpu topology helpers

### DIFF
--- a/python/toolbox/cdm_metrics.py
+++ b/python/toolbox/cdm_metrics.py
@@ -1,0 +1,142 @@
+# -*- mode: python; indent-tabs-mode: nil; python-indent-level: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python
+
+import json
+import lzma
+
+
+class CDMMetrics:
+    """Thread-safe metric tracker for CDM post-processing.
+
+    Each instance maintains its own state, so multiple threads or
+    processes can each have their own CDMMetrics without conflicts.
+    """
+
+    def __init__(self):
+        self.metric_types = []
+        self.file_id = None
+        self.metric_data_fh = {}
+        self.metric_idx = {}
+        self.stored_sample = {}
+        self.num_written_samples = {}
+        self.interval = {}
+        self.total_logged_samples = 0
+        self.total_cons_samples = 0
+        self.metric_data_file_prefix = ""
+
+    def _get_metric_label(self, desc, names):
+        label = desc["source"] + ":" + desc["type"] + ":"
+        for name in sorted(names.keys()):
+            value = str(names[name]) if names[name] else "x"
+            label += "<" + name + ":" + value + ">"
+        return label
+
+    def _write_sample(self, idx, begin, end, value):
+        if self.file_id is None:
+            raise RuntimeError("Cannot write sample because file_id is undefined")
+        if self.file_id not in self.metric_data_fh:
+            raise RuntimeError("Cannot write sample with undefined file handle: " + self.file_id)
+        self.metric_data_fh[self.file_id].write(
+            str(idx) + "," + str(begin) + "," + str(end) + "," + str(value) + "\n"
+        )
+        if idx not in self.num_written_samples:
+            self.num_written_samples[idx] = 1
+        else:
+            self.num_written_samples[idx] += 1
+
+    def log_sample(self, file_id, desc, names, sample):
+        self.file_id = file_id
+        self.metric_data_file_prefix = "metric-data-" + file_id
+        metric_data_file = self.metric_data_file_prefix + ".csv.xz"
+        label = self._get_metric_label(desc, names)
+
+        if label in self.metric_idx:
+            idx = self.metric_idx[label]
+            if idx not in self.interval and self.stored_sample[idx]["end"]:
+                self.interval[idx] = sample["end"] - self.stored_sample[idx]["end"]
+            if idx in self.stored_sample and "begin" not in self.stored_sample[idx]:
+                if idx in self.interval:
+                    self.stored_sample[idx]["begin"] = (
+                        self.stored_sample[idx]["end"] - self.interval[idx] + 1
+                    )
+                else:
+                    raise RuntimeError(
+                        f"interval [{idx}] should have been defined, but it is not"
+                    )
+            if self.stored_sample[idx]["value"] != sample["value"]:
+                self._write_sample(
+                    idx,
+                    self.stored_sample[idx]["begin"],
+                    self.stored_sample[idx]["end"],
+                    self.stored_sample[idx]["value"],
+                )
+                self.total_cons_samples += 1
+                if "begin" in sample:
+                    self.stored_sample[idx]["begin"] = sample["begin"]
+                else:
+                    self.stored_sample[idx]["begin"] = self.stored_sample[idx]["end"] + 1
+                self.stored_sample[idx]["end"] = sample["end"]
+                self.stored_sample[idx]["value"] = sample["value"]
+            else:
+                self.stored_sample[idx]["end"] = sample["end"]
+            self.total_logged_samples += 1
+        else:
+            self.metric_idx[label] = len(self.metric_types)
+            idx = self.metric_idx[label]
+            self.metric_types.append({"desc": desc.copy(), "names": names.copy()})
+            if file_id not in self.metric_data_fh:
+                self.metric_data_fh[file_id] = lzma.open(metric_data_file, "wt")
+            self.stored_sample[idx] = sample.copy()
+
+    def finish_samples(self, dont_delete=False):
+        if self.file_id is None:
+            return None
+
+        num_deletes = 0
+        for idx in range(len(self.stored_sample)):
+            if self.file_id in self.metric_data_fh:
+                if (
+                    self.stored_sample[idx]["value"] == 0
+                    and idx not in self.num_written_samples
+                    and not dont_delete
+                ):
+                    self.metric_types[idx]["purge"] = 1
+                    num_deletes += 1
+                else:
+                    begin = self.stored_sample[idx].get("begin", self.stored_sample[idx]["end"])
+                    self._write_sample(
+                        idx,
+                        begin,
+                        self.stored_sample[idx]["end"],
+                        self.stored_sample[idx]["value"],
+                    )
+                    self.metric_types[idx]["idx"] = idx
+
+        self.stored_sample = {}
+        self.interval = {}
+        self.metric_idx = {}
+
+        if self.file_id in self.metric_data_fh:
+            self.metric_data_fh[self.file_id].close()
+            del self.metric_data_fh[self.file_id]
+
+        new_metric_types = []
+        for idx in range(len(self.metric_types)):
+            if self.metric_types[idx].get("purge") == 1:
+                continue
+            new_metric_types.append({
+                "idx": self.metric_types[idx]["idx"],
+                "desc": self.metric_types[idx]["desc"],
+                "names": self.metric_types[idx]["names"],
+            })
+
+        if new_metric_types:
+            json_file = "metric-data-" + self.file_id + ".json.xz"
+            with lzma.open(json_file, "wt") as fh:
+                json.dump(new_metric_types, fh)
+
+        prefix = self.metric_data_file_prefix
+        self.metric_types = []
+        self.file_id = None
+        self.num_written_samples = {}
+        return prefix

--- a/python/toolbox/system_cpu_topology.py
+++ b/python/toolbox/system_cpu_topology.py
@@ -1,5 +1,7 @@
 import copy
 import logging
+import os
+import re
 from pathlib import Path
 
 log_format = '%(asctime)s %(levelname)s: %(message)s'
@@ -458,3 +460,84 @@ class system_cpu_topology:
                         break
 
         return(formatted_list)
+
+
+def build_cpu_topology(cpu_topo_path):
+    """Build a lightweight CPU topology dict from a sysfs cpu directory.
+
+    Matches the Perl toolbox::cpu::build_cpu_topology interface.
+    Returns a dict keyed by CPU ID with values containing
+    package_id, die_id, core_id, and thread_id.
+    """
+    cpu_topo = {}
+    if not os.path.isdir(cpu_topo_path):
+        return cpu_topo
+
+    for entry in sorted(os.listdir(cpu_topo_path)):
+        m = re.match(r'^cpu(\d+)$', entry)
+        if not m:
+            continue
+        cpu_id = int(m.group(1))
+        online_path = os.path.join(cpu_topo_path, entry, "online")
+        if os.path.exists(online_path):
+            with open(online_path) as f:
+                if f.read().strip().split('\x00')[0].strip() != "1":
+                    continue
+
+        topo_path = os.path.join(cpu_topo_path, entry, "topology")
+        if not os.path.isdir(topo_path):
+            continue
+
+        topo = {}
+        for field in ("physical_package_id", "die_id", "core_id"):
+            fpath = os.path.join(topo_path, field)
+            if os.path.exists(fpath):
+                with open(fpath) as f:
+                    val = f.read().strip().split('\x00')[0].strip()
+            else:
+                val = "0"
+            key = "package_id" if field == "physical_package_id" else field
+            topo[key] = int(val)
+
+        siblings_file = os.path.join(topo_path, "thread_siblings_list")
+        if os.path.exists(siblings_file):
+            with open(siblings_file) as f:
+                siblings_list = f.read().strip().split('\x00')[0].strip()
+            thread_id = 0
+            found = False
+            for rng in siblings_list.split(","):
+                range_m = re.match(r'(\d+)-(\d+)', rng)
+                if range_m:
+                    for i in range(int(range_m.group(1)), int(range_m.group(2)) + 1):
+                        if i == cpu_id:
+                            topo["thread_id"] = thread_id
+                            found = True
+                            break
+                        thread_id += 1
+                else:
+                    if int(rng) == cpu_id:
+                        topo["thread_id"] = thread_id
+                        found = True
+                        break
+                    thread_id += 1
+                if found:
+                    break
+
+        cpu_topo[cpu_id] = topo
+    return cpu_topo
+
+
+def get_cpu_topology(cpu_num, cpu_topo):
+    """Get (package, die, core, thread) for a CPU number.
+
+    Matches the Perl toolbox::cpu::get_cpu_topology interface.
+    """
+    if cpu_num in cpu_topo:
+        t = cpu_topo[cpu_num]
+        return (
+            t.get("package_id", 0),
+            t.get("die_id", 0),
+            t.get("core_id", 0),
+            t.get("thread_id", 0),
+        )
+    return (0, 0, cpu_num, 0)


### PR DESCRIPTION
## Summary
- Add `toolbox.cdm_metrics` with `CDMMetrics` class — thread-safe metric logging where each instance maintains its own state (unlike the existing `metrics.py` which uses module-level globals)
- Add `build_cpu_topology()` and `get_cpu_topology()` helper functions to `system_cpu_topology.py`, matching the Perl `toolbox::cpu` interface. Handles null bytes in sysfs files copied from containers.

These support porting benchmark/tool post-processors to Python3 with threading. The existing `metrics.py` is unchanged — callers migrate incrementally.

## Test plan
- [x] sysstat-post-process.py validated with `crucible run` (fio benchmark, 2 successful runs)
- [x] procstat-post-process.py validated with `crucible run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)