### PR TITLE
feat: add VERBOSE log level and configure root logger in setup_logging

### DIFF
--- a/python/toolbox/logging.py
+++ b/python/toolbox/logging.py
@@ -4,19 +4,29 @@
 import logging
 import sys
 
+VERBOSE = 15
+logging.addLevelName(VERBOSE, "VERBOSE")
+
 
 def setup_logging(name, level="normal"):
-    """Configure logging with a standard format.
+    """Configure logging on the root logger and return a named logger.
+
+    Configures the root logger so that all loggers in the process
+    (including library loggers like roadblock) inherit the handler
+    and level. Callers that want to suppress library output at normal
+    level can raise the root logger level after this call while
+    keeping their named logger at a lower level.
 
     Args:
         name: logger name (typically the script name)
-        level: "normal", "debug", or a Python logging level name
+        level: "normal", "verbose", "debug", or a Python logging level name
 
     Returns:
         configured logger instance
     """
     level_map = {
         "normal": logging.INFO,
+        "verbose": VERBOSE,
         "debug": logging.DEBUG,
         "warning": logging.WARNING,
         "error": logging.ERROR,
@@ -24,14 +34,24 @@ def setup_logging(name, level="normal"):
 
     log_level = level_map.get(level, logging.INFO)
 
-    logger = logging.getLogger(name)
-    logger.setLevel(log_level)
+    root = logging.getLogger()
+    root.setLevel(log_level)
 
-    if not logger.handlers:
+    format_map = {
+        "normal": "%(message)s",
+        "verbose": "[%(asctime)s][%(levelname)8s] %(message)s",
+        "debug": "[CODE][%(module)s %(funcName)s:%(lineno)d]\n[%(asctime)s][%(levelname) 8s][%(threadName)s] %(message)s",
+    }
+    fmt = format_map.get(level, "%(message)s")
+
+    if not root.handlers:
         handler = logging.StreamHandler(sys.stdout)
         handler.setLevel(log_level)
-        formatter = logging.Formatter("%(message)s")
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
+        handler.setFormatter(logging.Formatter(fmt))
+        root.addHandler(handler)
+    else:
+        for handler in root.handlers:
+            handler.setLevel(log_level)
+            handler.setFormatter(logging.Formatter(fmt))
 
-    return logger
+    return logging.getLogger(name)


### PR DESCRIPTION
## Summary
- Add custom VERBOSE level (15) between DEBUG and INFO for intermediate verbosity
- Switch setup_logging to configure the root logger so library loggers (roadblock, etc.) inherit the handler
- Log format varies by level: message-only at normal, timestamps at verbose, full code location at debug
- Prerequisite for rickshaw --log-level support

## Test plan
- [ ] Syntax check passes
- [ ] Existing callers (rickshaw-run.py) work without changes at normal level
- [ ] VERBOSE level correctly filters between INFO and DEBUG

🤖 Generated with [Claude Code](https://claude.com/claude-code)