### PR TITLE
feat: add logger.verbose() convenience method

### DIFF
--- a/python/toolbox/logging.py
+++ b/python/toolbox/logging.py
@@ -8,6 +8,14 @@ VERBOSE = 15
 logging.addLevelName(VERBOSE, "VERBOSE")
 
 
+def _verbose(self, message, *args, **kws):
+    if self.isEnabledFor(VERBOSE):
+        self._log(VERBOSE, message, args, **kws)
+
+
+logging.Logger.verbose = _verbose
+
+
 def setup_logging(name, level="normal"):
     """Configure logging on the root logger and return a named logger.
 


### PR DESCRIPTION
## Summary
- Add `verbose()` method to all loggers for the VERBOSE (15) level
- Allows `logger.verbose("msg")` instead of `logger.log(VERBOSE, "msg")`
- Follows the same pattern as roadblock's `verbose_debug` method

## Test plan
- [ ] `logger.verbose("test")` produces output at verbose level
- [ ] No output at normal level
- [ ] Shows at both verbose and debug levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)