### PR TITLE
CDMMetrics: clean up stale metric-data files before post-processing

### DIFF
--- a/python/toolbox/cdm_metrics.py
+++ b/python/toolbox/cdm_metrics.py
@@ -1,8 +1,11 @@
 # -*- mode: python; indent-tabs-mode: nil; python-indent-level: 4 -*-
 # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python
 
+import glob
 import json
 import lzma
+import os
+import threading
 
 
 class CDMMetrics:
@@ -11,6 +14,21 @@ class CDMMetrics:
     Each instance maintains its own state, so multiple threads or
     processes can each have their own CDMMetrics without conflicts.
     """
+
+    _cleanup_lock = threading.Lock()
+    _cleaned_up = False
+
+    @classmethod
+    def _cleanup_stale_files(cls):
+        """Remove stale metric-data files from a previous post-processing run.
+
+        Called once per process on the first log_sample(). Thread-safe.
+        """
+        with cls._cleanup_lock:
+            if not cls._cleaned_up:
+                for f in glob.glob("metric-data-*"):
+                    os.remove(f)
+                cls._cleaned_up = True
 
     def __init__(self):
         self.metric_types = []
@@ -45,6 +63,7 @@ class CDMMetrics:
             self.num_written_samples[idx] += 1
 
     def log_sample(self, file_id, desc, names, sample):
+        CDMMetrics._cleanup_stale_files()
         self.file_id = file_id
         self.metric_data_file_prefix = "metric-data-" + file_id
         metric_data_file = self.metric_data_file_prefix + ".csv.xz"


### PR DESCRIPTION
## Summary

When a post-processor is re-run (via `crucible postprocess` or manually), stale `metric-data-*.csv.xz` and `metric-data-*.json.xz` files from a previous run may remain if the new run produces a different number of output files. While `metric-data-*.json` indicates which files to use for indexing, the stale files create confusion during development and debugging.

## Change

Add a class-level cleanup method to `CDMMetrics` that removes all existing `metric-data-*` files in the current directory on the first `log_sample()` call per process. Uses a `threading.Lock` to ensure thread safety when post-processors use multiple threads (e.g., sysstat mpstat with 8 forks, procstat with 4 forks).

## How it works

- `_cleanup_stale_files()` is a `@classmethod` with a class-level `_cleaned_up` flag
- Called at the top of `log_sample()` before any file creation
- Runs exactly once per process regardless of how many `CDMMetrics` instances are created
- Thread-safe via `_cleanup_lock`

## Context

Discovered while building the `tool-ethtool` crucible tool. The post-processor creates one `CDMMetrics` instance per network interface, each with a unique `file_id`. When iterating on the post-processor and re-running `crucible postprocess`, old metric-data files from previous runs with different file counts would remain, causing confusion about which files were current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)