### PR TITLE
feat: write post-processing artifacts to postprocess/ subdirectory

### DIFF
--- a/python/toolbox/cdm_metrics.py
+++ b/python/toolbox/cdm_metrics.py
@@ -1,11 +1,12 @@
 # -*- mode: python; indent-tabs-mode: nil; python-indent-level: 4 -*-
 # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python
 
-import glob
 import json
 import lzma
 import os
-import threading
+
+
+POSTPROCESS_DIR = "postprocess"
 
 
 class CDMMetrics:
@@ -15,22 +16,8 @@ class CDMMetrics:
     processes can each have their own CDMMetrics without conflicts.
     """
 
-    _cleanup_lock = threading.Lock()
-    _cleaned_up = False
-
-    @classmethod
-    def _cleanup_stale_files(cls):
-        """Remove stale metric-data files from a previous post-processing run.
-
-        Called once per process on the first log_sample(). Thread-safe.
-        """
-        with cls._cleanup_lock:
-            if not cls._cleaned_up:
-                for f in glob.glob("metric-data-*"):
-                    os.remove(f)
-                cls._cleaned_up = True
-
-    def __init__(self):
+    def __init__(self, output_dir=POSTPROCESS_DIR):
+        self.output_dir = output_dir
         self.metric_types = []
         self.file_id = None
         self.metric_data_fh = {}
@@ -41,6 +28,7 @@ class CDMMetrics:
         self.total_logged_samples = 0
         self.total_cons_samples = 0
         self.metric_data_file_prefix = ""
+        os.makedirs(self.output_dir, exist_ok=True)
 
     def _get_metric_label(self, desc, names):
         label = desc["source"] + ":" + desc["type"] + ":"
@@ -63,10 +51,9 @@ class CDMMetrics:
             self.num_written_samples[idx] += 1
 
     def log_sample(self, file_id, desc, names, sample):
-        CDMMetrics._cleanup_stale_files()
         self.file_id = file_id
         self.metric_data_file_prefix = "metric-data-" + file_id
-        metric_data_file = self.metric_data_file_prefix + ".csv.xz"
+        metric_data_file = os.path.join(self.output_dir, self.metric_data_file_prefix + ".csv.xz")
         label = self._get_metric_label(desc, names)
 
         if label in self.metric_idx:
@@ -150,7 +137,7 @@ class CDMMetrics:
             })
 
         if new_metric_types:
-            json_file = "metric-data-" + self.file_id + ".json.xz"
+            json_file = os.path.join(self.output_dir, "metric-data-" + self.file_id + ".json.xz")
             with lzma.open(json_file, "wt") as fh:
                 json.dump(new_metric_types, fh)
 

--- a/python/toolbox/metrics.py
+++ b/python/toolbox/metrics.py
@@ -1,7 +1,10 @@
 import copy
 import json
 import lzma
+import os
 from pathlib import Path
+
+from toolbox.cdm_metrics import POSTPROCESS_DIR
 
 global metric_types
 metric_types = []
@@ -25,6 +28,8 @@ global metric_data_file_prefix
 metric_data_file_prefix = ''
 global metric_data_file
 metric_data_file = ''
+global output_dir
+output_dir = POSTPROCESS_DIR
 
 
 def write_sample(idx: str, begin: int, end: int, value: float):
@@ -101,7 +106,8 @@ def log_sample(this_file_id: str, desc: object, names: object, sample: object):
     global file_id, total_logged_samples, total_cons_samples, stored_sample, metric_data_file_prefix
     file_id = this_file_id
     metric_data_file_prefix = "metric-data-" + file_id
-    metric_data_file = metric_data_file_prefix + ".csv.xz"
+    os.makedirs(output_dir, exist_ok=True)
+    metric_data_file = os.path.join(output_dir, metric_data_file_prefix + ".csv.xz")
     label = get_metric_label(desc, names)
     if label in metric_idx:
         # This is not the first sample for this metric_type (of this label)
@@ -203,7 +209,7 @@ def finish_samples(dont_delete=False):
                        'names': metric_types[idx]['names'] }
             new_metric_types.append(metric)
         if len(new_metric_types) > 0:
-            file = "metric-data-" + file_id + ".json.xz"
+            file = os.path.join(output_dir, "metric-data-" + file_id + ".json.xz")
             with lzma.open(file, 'wt') as json_file:
                 json.dump(new_metric_types, json_file)
             json_file.close()


### PR DESCRIPTION
## Summary
- CDMMetrics now accepts an `output_dir` parameter (default `"postprocess"`) and writes all metric-data files there
- Legacy `metrics.py` module uses the same `postprocess` output directory
- Removes the `_cleanup_stale_files` hack that was tacked onto `log_sample()` — cleanup is now the orchestrator's responsibility

## Jira
[PERFNFV-316](https://redhat.atlassian.net/browse/PERFNFV-316)

## Design
Post-processing artifacts (metric-data files, post-process-data.json) now go into a dedicated `postprocess/` subdirectory inside each sample/tool directory. This creates a clean boundary between run-time data and post-processing output. Re-processing becomes `rm -rf postprocess/` — no filename-dependent glob patterns.

## Test plan
- [ ] Run a benchmark — verify metric-data files land in `postprocess/`
- [ ] Re-run post-processing — verify stale files are cleaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)