### PR TITLE
feat: add toolbox-python-deps to default userenv requirements

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -7,7 +7,9 @@
     "userenvs": [
         {
             "name": "default",
-            "requirements": []
+            "requirements": [
+                "toolbox-python-deps"
+            ]
         },
         {
             "name": "crucible-controller",


### PR DESCRIPTION
The toolbox Python library (toolbox.json) uses jsonschema for JSON validation. Previously, the jsonschema pip package was only declared as a requirement in the crucible-controller userenv, not in the default userenv. This meant engine images built with the default userenv lacked jsonschema at runtime.

bench-trafficgen depends on toolbox for post-processing (trafficgen-post-process.py imports toolbox.json.load_json_file and toolbox.cdm_metrics.CDMMetrics). When toolbox.json is imported, it pulls in jsonschema for its validate() and exceptions usage. Without jsonschema installed in the engine image, trafficgen post-processing fails with an ImportError.

While trafficgen's own client-workshop.json already installs jsonschema for the client role, the server role and any other benchmark or tool that uses toolbox's Python JSON utilities in the default userenv would also hit this missing dependency. Adding toolbox-python-deps to the default userenv ensures jsonschema is available wherever toolbox's Python modules are used.