### PR TITLE
feat: add verbose-debug log level to setup_logging()

### DIFF
--- a/python/toolbox/logging.py
+++ b/python/toolbox/logging.py
@@ -27,7 +27,7 @@ def setup_logging(name, level="normal"):
 
     Args:
         name: logger name (typically the script name)
-        level: "normal", "verbose", "debug", or a Python logging level name
+        level: "normal", "verbose", "debug", "verbose-debug", or a Python logging level name
 
     Returns:
         configured logger instance
@@ -36,6 +36,7 @@ def setup_logging(name, level="normal"):
         "normal": logging.INFO,
         "verbose": VERBOSE,
         "debug": logging.DEBUG,
+        "verbose-debug": logging.DEBUG,
         "warning": logging.WARNING,
         "error": logging.ERROR,
     }
@@ -49,6 +50,7 @@ def setup_logging(name, level="normal"):
         "normal": "%(message)s",
         "verbose": "[%(asctime)s][%(levelname)8s] %(message)s",
         "debug": "[CODE][%(module)s %(funcName)s:%(lineno)d]\n[%(asctime)s][%(levelname) 8s][%(threadName)s] %(message)s",
+        "verbose-debug": "[CODE][%(module)s %(funcName)s:%(lineno)d]\n[%(asctime)s][%(levelname) 8s][%(threadName)s] %(message)s",
     }
     fmt = format_map.get(level, "%(message)s")
 


### PR DESCRIPTION
## Summary
- Add `verbose-debug` as a recognized log level in `setup_logging()`, mapping to `logging.DEBUG` with the same format as `debug`
- Enables a standard four-level vocabulary (`normal`, `verbose`, `debug`, `verbose-debug`) across all crucible components
- In toolbox, `verbose-debug` behaves identically to `debug` — the distinction matters only in components that use roadblock's custom `VERBOSE_DEBUG_LEVEL` directly (endpoints, engine scripts)
- Part of [PERFNFV-323](https://redhat.atlassian.net/browse/PERFNFV-323)

## Test plan
- [ ] Verify `setup_logging("test", "verbose-debug")` produces DEBUG-level output with the debug format
- [ ] Verify existing levels (`normal`, `verbose`, `debug`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)