### PR TITLE
fix: cgroup2 always-true check and json.py unreachable exception handlers

### DIFF
--- a/bash/library/bench-base
+++ b/bash/library/bench-base
@@ -75,7 +75,7 @@ function validate_label() {
     id=`echo $RS_CS_LABEL | awk -F- '{print $2}'`
     re='^[1-9][0-9]*$'
     if [[ ! "$id" =~ $re ]]; then
-        echo "ID must a be a positive interger, exiting"
+        echo "ID must be a positive integer, exiting"
         exit 1
     fi
 }
@@ -135,9 +135,9 @@ function cgroup2()
     cmd=$(mount | grep cgroup | awk '{ print $1 }')
     if [[ "$cmd" =~ "cgroup2" ]]; then
        echo "cgroup_v2 is present"
-       return 1
+       return 0
      fi
-    return 0
+    return 1
 }
 
 function show_balance()
@@ -145,7 +145,7 @@ function show_balance()
     set -x
     local cpulist="$1"; shift
     dmesg | grep -i sched-domain
-    if [[ cgroup_v2 ]]; then
+    if cgroup2; then
         grep . /sys/fs/cgroup/cgroup.subtree_control
     else
         for cpu in `echo ${cpulist} | sed -e 's/,/ /g'`; do
@@ -212,7 +212,7 @@ function enable_balance()
     local cpulist="$1"; shift
     local debug="$1"; shift
     echo Y > /sys/kernel/debug/sched/verbose
-    if [[ cgroup_v2 ]]; then
+    if cgroup2; then
         enable_balance_v2
     else
         enable_balance_v1 $cpulist
@@ -226,7 +226,7 @@ function disable_balance()
     local cpulist="$1"; shift
     local debug="$1"; shift
     echo Y > /sys/kernel/debug/sched/verbose
-    if [[ cgroup_v2 ]]; then
+    if cgroup2; then
         disable_balance_v2 $cpulist
     else
         disable_balance_v1 $cpulist

--- a/python/toolbox/json.py
+++ b/python/toolbox/json.py
@@ -21,13 +21,13 @@ def load_json_file(json_file, uselzma = False):
     except FileNotFoundError as err:
         err_msg = f"Could not find JSON file { json_file }:{ err }"
     except IOError as err:
-        err_msg = "Could not open/read JSON file { json_file }:{ err }"
-    except Exception as err:
-        err_msg = f"Unexpected error opening JSON file { json_file }:{ err }"
-    except JSONDecodeError as err:
-        err_msg = f"Decoding JSON file %s has failed: { json_file }:{ err }"
+        err_msg = f"Could not open/read JSON file { json_file }:{ err }"
+    except json.JSONDecodeError as err:
+        err_msg = f"Decoding JSON file { json_file } has failed: { err }"
     except TypeError as err:
         err_msg = f"JSON object type error: { err }"
+    except Exception as err:
+        err_msg = f"Unexpected error opening JSON file { json_file }:{ err }"
     return None, err_msg
 
 


### PR DESCRIPTION
## Summary

Two independent bug fixes, one per commit:

- **bench-base cgroup2**: `cgroup2()` returned inverted exit codes (1=present, 0=absent), and all three callers used `if [[ cgroup_v2 ]]` which tests a string literal (always true). The cgroup v2 code path was taken on every system regardless of actual cgroup version. Fix: correct return codes and change callers to `if cgroup2; then`.

- **json.py load_json_file**: Missing `f` prefix on IOError handler showed literal braces. `except Exception` before `JSONDecodeError`/`TypeError` made specific handlers unreachable. `JSONDecodeError` not qualified with `json.` module prefix. Fix: add `f` prefix, reorder handlers, qualify `json.JSONDecodeError`.

Closes #121
Closes #122

## Test plan
- [ ] On a cgroup v2 system: source bench-base, verify `cgroup2` returns 0 and `show_balance`/`disable_balance`/`enable_balance` take the v2 path
- [ ] On a cgroup v1 system: verify `cgroup2` returns 1 and functions take the v1 path
- [ ] Python: `from toolbox.json import load_json_file; load_json_file("/nonexistent")` — verify error message includes the file path (not literal braces)
- [ ] Python: `load_json_file` with a file containing invalid JSON — verify `json.JSONDecodeError` handler fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)